### PR TITLE
Use json logs

### DIFF
--- a/configs/config_without_sa.json
+++ b/configs/config_without_sa.json
@@ -88,6 +88,11 @@
     "logging": { "loglevel": "debug" }
   },
   "service": {
+    "telemetry": {
+      "logs": {
+        "encoding": "json"
+      }
+    },
     "pipelines": {
       "traces": {
         "receivers": ["otlp"],


### PR DESCRIPTION
There are still a few lines that are not JSON, but this should clean up the majority of logs emitted by the collector.