### PR TITLE
Default HOSTNAME from OS if not in env

### DIFF
--- a/scripts/01-otel-config-buildpack-defaults.sh
+++ b/scripts/01-otel-config-buildpack-defaults.sh
@@ -10,3 +10,5 @@ if [[ -n $LOVES_OTEL_REDACTED_QUERY_PARAMS ]]
 then
   $HOME/.heroku/node/bin/node $HOME/.profile.d/setup-query-param-redaction.mjs
 fi
+
+export HOSTNAME=${HOSTNAME:-$(hostname)}

--- a/scripts/01-otel-config-buildpack-defaults.sh
+++ b/scripts/01-otel-config-buildpack-defaults.sh
@@ -12,3 +12,4 @@ then
 fi
 
 export HOSTNAME=${HOSTNAME:-$(hostname)}
+echo "HOSTNAME set to $HOSTNAME"


### PR DESCRIPTION
This is a workaround for https://github.com/open-telemetry/opentelemetry-js/issues/4405. The web dynos do not appear to have `HOSTNAME` set in Heroku, so we’re setting it from the OS if it doesn’t already exist.

AB#363557