### PR TITLE
Remove `ballast_size_mib` memory_limiter processor config

### DIFF
--- a/configs/config_without_sa.json
+++ b/configs/config_without_sa.json
@@ -17,7 +17,6 @@
   "processors": {
     "batch": null,
     "memory_limiter": {
-      "ballast_size_mib": "${SPLUNK_BALLAST_SIZE_MIB}",
       "check_interval": "2s",
       "limit_mib": "${SPLUNK_MEMORY_LIMIT_MIB}"
     },


### PR DESCRIPTION
The `memory_ballast` [extension](https://docs.splunk.com/observability/en/gdi/opentelemetry/components/memory-ballast-extension.html) was removed in [v0.97](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.97.0) of Splunk's OpenTelemetry Collector. `SPLUNK_BALLAST_SIZE_MIB` was a part of this extension. Any builds going forward using a buildpack which expects `SPLUNK_BALLAST_SIZE_MIB` without the extension will fail to start the collector.

We weren't customizing the `memory_ballast` (previously `ballast_size_mib` under the `memory_limiter` processor)—they recommend removing it if you aren't doing so—and they now recommend customizing it through `GOMEMLIMIT`. They now set a default limit to handle garbage collection frequency, which we can customize if we'd like:

```
memory_ballast is no longer effective. The garbage collection is now controlled by the soft memory limit set to 90% of total memory (SPLUNK_MEMORY_TOTAL_MIB env var) by default.

If you haven't customized the memory_ballast, just remove it from the configuration.

If you have customized it via SPLUNK_BALLAST_SIZE_MIB (or extensions::memory_ballast::size_mib config), you should remove the memory_ballast extension and use the [GOMEMLIMIT](https://pkg.go.dev/runtime) environment variable to set a custom soft memory limit:

To increase frequency of garbage collections: set GOMEMLIMIT to a higher value than the default 90% of total memory.
To decrease frequency of garbage collections: set GOMEMLIMIT to a lower value than the default 90% of total memory.
```