### PR TITLE
Migrate from logging exporter to the debug exporter

### DIFF
--- a/configs/config_without_sa.json
+++ b/configs/config_without_sa.json
@@ -84,7 +84,7 @@
       "access_token": "${SPLUNK_ACCESS_TOKEN}",
       "endpoint": "${SPLUNK_TRACE_URL}"
     },
-    "logging": { "loglevel": "debug" }
+    "debug": { "verbosity": "detailed" }
   },
   "service": {
     "telemetry": {


### PR DESCRIPTION
The logging exporter was removed in [v0.112.0](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.112.0) of the splunk-otel-collector. The debug exporter is the new thing. [Here's](https://github.com/open-telemetry/opentelemetry-collector/issues/11337) the migration guide.